### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,11 +2,11 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   
   def index
-    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new
-    @item = Item.new.order(created_at: :desc)
+    @item = Item.new
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   
   def index
-    #@items = Item.all
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
   end
 
   def new
-    @item = Item.new
+    @item = Item.new.order(created_at: :desc)
   end
 
   def create

--- a/app/javascript/price.js
+++ b/app/javascript/price.js
@@ -1,20 +1,28 @@
-  // 価格の入力フィールド
-  const priceInput = document.getElementById('item-price');
-  // 販売手数料の表示要素
-  const addTaxPrice = document.getElementById('add-tax-price');
-  // 販売利益の表示要素
-  const profit = document.getElementById('profit');
+const priceInput = document.getElementById('item-price');
+const addTaxPrice = document.getElementById('add-tax-price');
+const profit = document.getElementById('profit');
 
-  // 入力フィールドにinputイベントリスナーを追加
-  priceInput.addEventListener('input', () => {
-    // 入力された価格を取得
-    const price = priceInput.value;
-    // 販売手数料を計算（価格の10%）
-    const tax = Math.floor(price * 0.1);
-    // 販売利益を計算（価格から販売手数料を引いた金額）
-    const profitAmount = Math.floor(price - tax);
+priceInput.addEventListener('input', () => {
+  const price = priceInput.value.trim(); // 入力の前後の空白をトリム
 
-    // 販売手数料と販売利益をHTMLに反映
-    addTaxPrice.textContent = tax.toLocaleString();
-    profit.textContent = profitAmount.toLocaleString();
-  });
+  // 入力が空の場合は何も表示しない
+  if (price === '') {
+    addTaxPrice.textContent = '';
+    profit.textContent = '';
+    return;
+  }
+
+  // 入力が半角数字以外の場合はNaNを表示する
+  if (!/^\d+$/.test(price)) {
+    addTaxPrice.textContent = 'NaN';
+    profit.textContent = 'NaN';
+    return;
+  }
+
+  const validPrice = parseInt(price, 10); // 価格を整数に変換
+  const tax = Math.floor(validPrice * 0.1);
+  const profitAmount = Math.floor(validPrice - tax);
+
+  addTaxPrice.textContent = tax.toLocaleString();
+  profit.textContent = profitAmount.toLocaleString();
+});

--- a/app/models/days_to_ship.rb
+++ b/app/models/days_to_ship.rb
@@ -1,8 +1,9 @@
 class DaysToShip < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' }
+    { id: 2, name: '1~2発送' },
+    { id: 3, name: '2~3発送' },
+    { id: 4, name: '4~7で発送' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -1,9 +1,8 @@
 class Delivery < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
-    { id: 2, name: '1~2発送' },
-    { id: 3, name: '2~3発送' },
-    { id: 4, name: '4~7で発送' }
+    { id: 2, name: '着払い(購入者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -26,4 +26,9 @@ class Item < ApplicationRecord
   def image_attached
     errors.add(:image, "must be attached") unless image.attached?
   end
+
+  def sold_out?
+    order.present?
+  end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   
-  #has_many :orders
+  has_many :orders
   has_many :items
 
   validates :name,            presence: true

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,8 @@
     <ul class='item-lists'>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item) do %>
+        <%= link_to "#" do %> <%# <=後でコメントアウトを外して消す %>
+        <%#= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag url_for(item.image), class: "item-img" %>
           <% if item.sold_out? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,26 +127,23 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%= image_tag url_for(item.image), class: "item-img" %>
+          <% if item.sold_out? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
+        <% end %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery.name  %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,12 +152,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @items.empty? %>
       <li class='list'>
-        <%= link_to '#' do %>
+        <%= link_to new_item_path do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -176,9 +172,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -97,7 +97,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"半角数字で入力" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -11,37 +11,44 @@ RSpec.describe Item, type: :model do
         expect(@item).to be_valid
       end
     end
+
     context '投稿できない場合' do
       it 'item_nameが空では保存できない' do
         @item.item_name = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Item name can't be blank")
       end
+
       it 'contentが空では保存できない' do
         @item.content = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Content can't be blank")
       end
+
       it 'imageが空では保存できない' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Image must be attached")
       end
+
       it 'categoryが選択されていなければ保存できない' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Category Category can't be blank")
       end
+
       it 'deliveryが選択されていなければ保存できない' do
         @item.delivery_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Delivery Shipping fee status can't be blank")
       end
+
       it 'cityが選択されていなければ保存できない' do
         @item.city_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("City Prefecture can't be blank")
       end
+      
       it 'days_to_shipが選択されていなければ保存できない' do
         @item.days_to_ship_id = 1
         @item.valid?
@@ -65,7 +72,7 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include("Price is not a number")
       end
-      
+
       it 'priceが300未満の値では保存できない' do
         @item.price = 299
         @item.valid?


### PR DESCRIPTION
# What
商品一覧表示機能を実装しました。
投稿した商品が全て並ぶように表示しました。
販売手数料 (10%)、販売利益もうまく表示されていなかったので修正しました。

# Why
一覧で並べることにより目につきやすく買い取られやすい。


 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/ce68069965cbebbfc6a4b96fb9651c86
 商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/5e70bb84923445ef022168c9e8f51be0
https://gyazo.com/54f600f94baad8ecced13b03bbf84b7c