### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index
     @items = Item.all.order(created_at: :desc)
@@ -37,14 +37,15 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-=begin
-  def destroy
-    @item = Item.find(params[:id])
-    @item.destroy
-    redirect_to '/'
-  end
-=end
 
+  def destroy
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path, notice: "商品情報を削除しました"
+    else
+      redirect_to root_path, alert: "権限がありません"
+    end
+  end
   private
   def item_params
     params.require(:item).permit(:item_name, :content, :price, :category_id, :delivery_id, :city_id, :days_to_ship_id, :status_id, :image).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,8 +27,7 @@
     <% if current_user == @item.user %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-      <%#= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class: "item-destroy" %>
+      <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class: "item-destroy" %>
     <% else %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <%#= link_to "購入画面に進む", orders_path(@item), class: "item-red-btn" %>


### PR DESCRIPTION
# What
商品削除機能を実装しました。

# Why
間違った商品を投稿した場合に削除するため。

 ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/d18b6e4fc42eec7fb05a4bb1bd1bb656